### PR TITLE
Fix picomatch ReDoS and method injection vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1762,7 +1762,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -3718,7 +3720,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
## Summary
- Ran `npm audit fix` to update picomatch transitive dependencies to patched versions
- Resolves all 4 Dependabot alerts: #33, #34 (high - ReDoS via extglob quantifiers) and #35, #36 (moderate - method injection in POSIX character classes)
- Only `package-lock.json` changed; no application code or direct dependency changes

## Test plan
- [x] `npm audit` reports 0 vulnerabilities after the fix
- [ ] Verify site builds successfully with `npm run build`

https://claude.ai/code/session_01RHqaETnXCfdYCAh3KRrz7T