### PR TITLE
Configure Dependabot schedule and add devcontainer updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,18 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"
+      day: "sunday"
+      time: "08:00"
+      timezone: "Europe/Berlin"
+
+  - package-ecosystem: "devcontainers"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "08:00"
+      timezone: "Europe/Berlin"


### PR DESCRIPTION
## Summary
Updated the Dependabot configuration to include specific scheduling details for npm dependency updates and added support for automated devcontainer dependency updates.

## Key Changes
- **npm updates**: Added explicit schedule configuration with weekly updates on Sundays at 08:00 Europe/Berlin timezone
- **devcontainer support**: Added new Dependabot configuration to check for updates in the `/.devcontainer` directory with the same weekly schedule
- **Code cleanup**: Removed inline comments from package ecosystem and directory fields for cleaner configuration

## Implementation Details
Both package ecosystems now follow the same update schedule (weekly on Sundays at 08:00 Europe/Berlin time), ensuring consistent and predictable dependency update timing across the project.

https://claude.ai/code/session_0197cenVVyt8DoEQQBSDjfw9