### PR TITLE
Bump astro, @astrojs/sitemap, and wrangler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,19 +8,19 @@
       "name": "astro-portfolio-v2",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/sitemap": "^3.7.1",
+        "@astrojs/sitemap": "^3.7.2",
         "@jop-software/astro-cookieconsent": "^3.0.0",
-        "astro": "^6.0.8",
+        "astro": "^6.1.0",
         "astro-robots-txt": "^1.0.0",
         "install": "^0.13.0",
         "vanilla-cookieconsent": "^3.0.1",
-        "wrangler": "^4.76.0"
+        "wrangler": "^4.77.0"
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-3.0.0.tgz",
-      "integrity": "sha512-MwAbDE5mawZ1SS+D8qWiHdprdME5Tlj2e0YjxnEICvcOpbSukNS7Sa7hA5PK+6RrmUr/t6Gi5YgrdZKjbO/WPQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-3.0.1.tgz",
+      "integrity": "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==",
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.0.1.tgz",
-      "integrity": "sha512-zAfLJmn07u9SlDNNHTpjv0RT4F8D4k54NR7ReRas8CO4OeGoqSvOuKwqCFg2/cqN3wHwdWlK/7Yv/lMXlhVIaw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.0.tgz",
+      "integrity": "sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/internal-helpers": "0.8.0",
@@ -51,6 +51,7 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
+        "retext-smartypants": "^6.2.0",
         "shiki": "^4.0.0",
         "smol-toml": "^1.6.0",
         "unified": "^11.0.5",
@@ -73,7 +74,9 @@
       }
     },
     "node_modules/@astrojs/sitemap": {
-      "version": "3.7.1",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
       "license": "MIT",
       "dependencies": {
         "sitemap": "^9.0.0",
@@ -1801,17 +1804,17 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.0.8.tgz",
-      "integrity": "sha512-DCPeb8GKOoFWh+8whB7Qi/kKWD/6NcQ9nd1QVNzJFxgHkea3WYrNroQRq4whmBdjhkYPTLS/1gmUAl2iA2Es2g==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.0.tgz",
+      "integrity": "sha512-J8XGJQo5+W2wJLdUbQHVho4DHWDM6V4Dp8s+z0Fs3O/mcu3WjbTBELOv/MC7ueoqmQ/Jts6Bz7FJwbAopbFd+g==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^3.0.0",
+        "@astrojs/compiler": "^3.0.1",
         "@astrojs/internal-helpers": "0.8.0",
-        "@astrojs/markdown-remark": "7.0.1",
+        "@astrojs/markdown-remark": "7.1.0",
         "@astrojs/telemetry": "3.3.0",
         "@capsizecss/unpack": "^4.0.0",
-        "@clack/prompts": "^1.0.1",
+        "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
         "@rollup/pluginutils": "^5.3.0",
         "aria-query": "^5.3.2",
@@ -1844,11 +1847,11 @@
         "picomatch": "^4.0.3",
         "rehype": "^13.0.2",
         "semver": "^7.7.4",
-        "shiki": "^4.0.0",
+        "shiki": "^4.0.2",
         "smol-toml": "^1.6.0",
-        "svgo": "^4.0.0",
-        "tinyclip": "^0.1.6",
-        "tinyexec": "^1.0.2",
+        "svgo": "^4.0.1",
+        "tinyclip": "^0.1.12",
+        "tinyexec": "^1.0.4",
         "tinyglobby": "^0.2.15",
         "tsconfck": "^3.1.6",
         "ultrahtml": "^1.6.0",
@@ -3495,9 +3498,9 @@
       "license": "MIT"
     },
     "node_modules/miniflare": {
-      "version": "4.20260317.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260317.1.tgz",
-      "integrity": "sha512-A3csI1HXEIfqe3oscgpoRMHdYlkReQKPH/g5JE53vFSjoM6YIAOGAzyDNeYffwd9oQkPWDj9xER8+vpxei8klA==",
+      "version": "4.20260317.2",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260317.2.tgz",
+      "integrity": "sha512-qNL+yWAFMX6fr0pWU6Lx1vNpPobpnDSF1V8eunIckWvoIQl8y1oBjL2RJFEGY3un+l3f9gwW9dirDPP26usYJQ==",
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -4753,16 +4756,16 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.76.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.76.0.tgz",
-      "integrity": "sha512-Wan+CU5a0tu4HIxGOrzjNbkmxCT27HUmzrMj6kc7aoAnjSLv50Ggcn2Ant7wNQrD6xW3g31phKupZJgTZ8wZfQ==",
+      "version": "4.77.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.77.0.tgz",
+      "integrity": "sha512-E2Gm69+K++BFd3QvoWjC290RPQj1vDOUotA++sNHmtKPb7EP6C8Qv+1D5Ii73tfZtyNgakpqHlh8lBBbVWTKAQ==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.2",
         "@cloudflare/unenv-preset": "2.16.0",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260317.1",
+        "miniflare": "4.20260317.2",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
         "workerd": "1.20260317.1"
@@ -4772,7 +4775,7 @@
         "wrangler2": "bin/wrangler.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.3.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/sitemap": "^3.7.1",
+    "@astrojs/sitemap": "^3.7.2",
     "@jop-software/astro-cookieconsent": "^3.0.0",
-    "astro": "^6.0.8",
+    "astro": "^6.1.0",
     "astro-robots-txt": "^1.0.0",
     "install": "^0.13.0",
     "vanilla-cookieconsent": "^3.0.1",
-    "wrangler": "^4.76.0"
+    "wrangler": "^4.77.0"
   },
   "overrides": {
     "devalue": "5.6.4",


### PR DESCRIPTION
## Summary\n- **astro** `6.0.8` → `6.1.0` (from #43)\n- **@astrojs/sitemap** `3.7.1` → `3.7.2` (from #41)\n- **wrangler** `4.76.0` → `4.77.0` (from #42)\n\nCombines all three Dependabot PRs into a single update. Build verified successfully.\n\n## Test plan\n- [x] `npm install` completes without errors\n- [x] `npm run build` passes with all 19 pages built\n- [ ] Verify site works as expected after deploy\n\nhttps://claude.ai/code/session_01TudjLZnrJCDcNs43saXxNf