### PR TITLE
Localize a11y labels, add social/SEO meta, polish German copy

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -57,24 +57,24 @@ export default defineConfig({
               footer: "<a href=\"https://pd-portfolio.net/privacy-policy/\">Datenschutz</a>\n<a href=\"https://pd-portfolio.net/privacy-policy/#impressum\">Impressum</a>",
             },
             preferencesModal: {
-              title: "Präferenzen für die Zustimmung",
-              closeIconLabel: "Modal schließen",
+              title: "Einstellungen zur Einwilligung",
+              closeIconLabel: "Dialog schließen",
               acceptAllBtn: "Alle akzeptieren",
               acceptNecessaryBtn: "Alle ablehnen",
               savePreferencesBtn: "Einstellungen speichern",
-              serviceCounterLabel: "Dienstleistungen",
+              serviceCounterLabel: "Dienst|Dienste",
               sections: [
                 {
                   title: "Verwendung von Cookies",
                   description: "Diese Seite wird über Cloudflare bereitgestellt, das Cookies für Performance und Sicherheit nutzen kann. Mit der Nutzung unserer Website stimmen Sie der Verwendung dieser Cookies zu. Details in unserer Datenschutzerklärung.",
                 },
                 {
-                  title: "Streng Notwendige Cookies <span class=\"pm__badge\">Immer Aktiviert</span>",
+                  title: "Streng notwendige Cookies <span class=\"pm__badge\">Immer aktiviert</span>",
                   description: "Zwingend notwendige Cookies sind unerlässlich für den Betrieb unserer Website. Ohne diese Cookies würde unsere Website nicht richtig funktionieren. Diese Cookies ermöglichen grundlegende Funktionen wie Seitennavigation und Zugriff auf sichere Bereiche der Website. Sie können in unseren Systemen nicht deaktiviert werden und werden in der Regel nur als Reaktion auf Aktionen gesetzt, die einer Anfrage nach Diensten entsprechen, wie z.B. das Festlegen Ihrer Datenschutzeinstellungen, das Einloggen oder das Ausfüllen von Formularen.",
                   linkedCategory: "necessary",
                 },
                 {
-                  title: "Funktionalitäts Cookies",
+                  title: "Funktionalitäts-Cookies",
                   description: "Funktionalitäts-Cookies ermöglichen es unserer Website, sich an Informationen zu erinnern, die die Art und Weise beeinflussen, wie sich die Website verhält oder aussieht, wie z.B. Ihre bevorzugte Sprache oder die Region, in der Sie sich befinden. Diese Cookies sorgen dafür, dass Ihre Präferenzen bei zukünftigen Besuchen beibehalten werden, um Ihnen eine personalisierte und verbesserte Benutzererfahrung zu bieten.",
                   linkedCategory: "functionality",
                 },
@@ -93,7 +93,7 @@ export default defineConfig({
               acceptAllBtn: "Accept all",
               acceptNecessaryBtn: "Reject all",
               showPreferencesBtn: "Manage preferences",
-              footer: "<a href=\"https://pd-portfolio.net/privacy-policy/\">Privacy Policy</a>\n<a href=\"https://pd-portfolio.net/privacy-policy/#impressum\">Terms and conditions</a>",
+              footer: "<a href=\"https://pd-portfolio.net/privacy-policy/\">Privacy Policy</a>\n<a href=\"https://pd-portfolio.net/privacy-policy/#impressum\">Legal Notice</a>",
             },
             preferencesModal: {
               title: "Consent Preferences Center",

--- a/src/components/LangSwitcher.astro
+++ b/src/components/LangSwitcher.astro
@@ -1,8 +1,9 @@
 ---
-import { getLangFromUrl, localizePath, stripLangFromPath } from '../i18n/utils';
+import { getLangFromUrl, useTranslations, localizePath, stripLangFromPath } from '../i18n/utils';
 import { languages, type Lang } from '../i18n/ui';
 
 const lang = getLangFromUrl(Astro.url);
+const t = useTranslations(lang);
 const basePath = stripLangFromPath(Astro.url.pathname);
 
 const options = (Object.keys(languages) as Lang[]).map((code) => ({
@@ -15,6 +16,8 @@ const options = (Object.keys(languages) as Lang[]).map((code) => ({
 
 <lang-switcher
 	class="flex items-center rounded-full border border-line p-0.5 font-mono text-xs"
+	role="group"
+	aria-label={t('a11y.switchLang')}
 >
 	{
 		options.map(({ code, href, label, active }) => (

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -17,6 +17,15 @@ const lang = getLangFromUrl(Astro.url);
 const basePath = stripLangFromPath(Astro.url.pathname);
 const enPath = localizePath(basePath, 'en');
 const dePath = localizePath(basePath, 'de');
+
+// Absolute URLs for canonical, hreflang and Open Graph. Astro.site is set in
+// astro.config.mjs, so these resolve to https://pd-portfolio.net/...
+const canonical = new URL(Astro.url.pathname, Astro.site).href;
+const enHref = new URL(enPath, Astro.site).href;
+const deHref = new URL(dePath, Astro.site).href;
+const ogImage = new URL('/icon-512.png', Astro.site).href;
+const ogLocale = lang === 'de' ? 'de_DE' : 'en_US';
+const ogLocaleAlt = lang === 'de' ? 'en_US' : 'de_DE';
 ---
 
 <meta charset="UTF-8" />
@@ -24,10 +33,11 @@ const dePath = localizePath(basePath, 'de');
 <meta name="viewport" content="width=device-width" />
 <meta name="generator" content={Astro.generator} />
 <title>{title}</title>
+<link rel="canonical" href={canonical} />
 
-<link rel="alternate" hreflang="en" href={enPath} />
-<link rel="alternate" hreflang="de" href={dePath} />
-<link rel="alternate" hreflang="x-default" href={enPath} />
+<link rel="alternate" hreflang="en" href={enHref} />
+<link rel="alternate" hreflang="de" href={deHref} />
+<link rel="alternate" hreflang="x-default" href={enHref} />
 
 <script is:inline define:vars={{ lang, enPath, dePath }}>
 	// Send visitors to their language on first load, then remember the choice.
@@ -56,7 +66,13 @@ const dePath = localizePath(basePath, 'de');
 <meta name="theme-color" content="#1f7ae0" />
 <meta property="og:title" content={title} />
 <meta property="og:type" content="website" />
-<meta name="twitter:card" content="summary_large_image" />
+<meta property="og:url" content={canonical} />
+<meta property="og:site_name" content="Paul Dresch" />
+<meta property="og:locale" content={ogLocale} />
+<meta property="og:locale:alternate" content={ogLocaleAlt} />
+<meta property="og:image" content={ogImage} />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:image" content={ogImage} />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,5 +1,9 @@
 ---
 import { Icon } from 'astro-icon/components';
+import { getLangFromUrl, useTranslations } from '../i18n/utils';
+
+const lang = getLangFromUrl(Astro.url);
+const t = useTranslations(lang);
 ---
 
 <theme-toggle>
@@ -7,7 +11,7 @@ import { Icon } from 'astro-icon/components';
 		type="button"
 		class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-line text-muted transition-colors hover:border-brand hover:text-brand"
 	>
-		<span class="sr-only">Toggle dark theme</span>
+		<span class="sr-only">{t('a11y.toggleTheme')}</span>
 		<Icon name="lucide:moon" class="h-4 w-4 dark:hidden" />
 		<Icon name="lucide:sun" class="hidden h-4 w-4 dark:block" />
 	</button>

--- a/src/components/pages/TerminalPage.astro
+++ b/src/components/pages/TerminalPage.astro
@@ -108,7 +108,7 @@ const terminalData = {
 						autocapitalize="off"
 						autocorrect="off"
 						spellcheck="false"
-						aria-label="Terminal input"
+						aria-label={t('a11y.terminalInput')}
 						class="w-full border-0 bg-transparent text-ink outline-none placeholder:text-subtle"
 					/>
 				</div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -11,8 +11,8 @@ const projects = defineCollection({
 		tags: z.array(z.string()).default([]),
 		// Concrete tech the project is built with, shown as badges.
 		stack: z.array(z.string()).default([]),
-		repoUrl: z.string().url().optional(),
-		liveUrl: z.string().url().optional(),
+		repoUrl: z.url().optional(),
+		liveUrl: z.url().optional(),
 		featured: z.boolean().default(false),
 		status: z.enum(['shipped', 'wip', 'archived']).default('shipped'),
 		// lucide icon name used for the card accent and image-less placeholder.

--- a/src/content/projects/de/diatrack.md
+++ b/src/content/projects/de/diatrack.md
@@ -22,7 +22,7 @@ Menschen, die mit Diabetes leben, verwalten nebenbei immer auch eine Menge Hardw
 
 - Verfolgt den Lebenszyklus jedes Sensors und Katheters und berechnet, wann ein Wechsel fällig ist.
 - Sendet automatisch Ablauferinnerungen, damit nichts vergessen wird.
-- Wird als einzelner Container-Web-App ausgeliefert, die man selbst hosten kann.
+- Wird als einzelne Container-Web-App ausgeliefert, die man selbst hosten kann.
 
 ### Warum es wichtig ist
 

--- a/src/content/projects/de/mailcow-cold-standby.md
+++ b/src/content/projects/de/mailcow-cold-standby.md
@@ -25,4 +25,4 @@ Ein Mailserver ist eines dieser Dinge, bei denen einem ein Backup erst einfällt
 
 ### Warum es wichtig ist
 
-Günstige, externe, automatisierte Backups für selbst gehostete E-Mail. Genau die Art von Dinge, die langweilig ist, bis zu dem Tag, an dem sie einen rettet.
+Günstige, externe, automatisierte Backups für selbst gehostete E-Mail. Genau die Art von Dingen, die langweilig ist, bis zu dem Tag, an dem sie einen rettet.

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -58,7 +58,7 @@ export const content = {
 			{
 				icon: 'lucide:network',
 				title: 'Netzwerke',
-				body: 'Zuhause von DNS und Mail-Security bis hin zu Datacenter-Switching, mit Fokus auf zuverlässige, gut verstandene Setups.',
+				body: 'Zu Hause von DNS und Mail-Security bis hin zu Datacenter-Switching, mit Fokus auf zuverlässige, gut verstandene Setups.',
 			},
 		],
 	},
@@ -76,6 +76,7 @@ export const ui = {
 		'a11y.menu': 'Menu',
 		'a11y.toggleTheme': 'Toggle dark theme',
 		'a11y.switchLang': 'Switch language',
+		'a11y.terminalInput': 'Terminal input',
 
 		// Footer
 		'footer.builtWith': 'Built in Untereuerheim with Astro and Tailwind.',
@@ -173,6 +174,7 @@ export const ui = {
 		'a11y.menu': 'Menü',
 		'a11y.toggleTheme': 'Dunkles Design umschalten',
 		'a11y.switchLang': 'Sprache wechseln',
+		'a11y.terminalInput': 'Terminal-Eingabe',
 
 		// Footer
 		'footer.builtWith': 'Gebaut in Untereuerheim mit Astro und Tailwind.',


### PR DESCRIPTION
Scraped the site for technical improvements and German wording fixes. Build and `astro check` both pass clean (0 errors, 0 warnings, 0 hints).

## Accessibility / i18n
- `a11y.toggleTheme` and `a11y.switchLang` were defined in the dictionary but **never wired up**. The theme toggle hardcoded English ("Toggle dark theme") and the language switcher had no group label, so German pages exposed an English-only screen-reader label. Both are now localized.
- The terminal input had a hardcoded English `aria-label`; added an `a11y.terminalInput` key and localized it.

## SEO / social
- Added `canonical`, `og:url`, `og:site_name`, `og:locale` (+ `og:locale:alternate`), `og:image`, and `twitter:image`. Previously there was **no canonical and no social preview image at all**.
- Made the `hreflang` alternate links absolute URLs (they were root-relative paths, which Google recommends against).
- Switched `twitter:card` from `summary_large_image` to `summary` to match the square icon asset we actually have.

## German wording / grammar
- `diatrack`: "als **einzelner** Container-Web-App" → "als **einzelne** Container-Web-App" (gender agreement).
- `mailcow-cold-standby`: "Art von **Dinge**" → "Art von **Dingen**" (Dativ).
- Skills card: "**Zuhause** von DNS..." → "**Zu Hause** von DNS..." (adverb, not noun).
- Cookie consent (`astro.config.mjs`): fixed German capitalization and phrasing — "Streng notwendige Cookies", "Immer aktiviert", "Funktionalitäts-Cookies", "Einstellungen zur Einwilligung", and `serviceCounterLabel` now uses the `Dienst|Dienste` singular/plural format. Also relabeled the EN footer link from "Terms and conditions" to "Legal Notice" (it points to the Impressum).

## Minor technical cleanup
- Replaced deprecated `z.string().url()` with `z.url()` in the content schema (removes the two `astro check` deprecation hints).

## Note on CLAUDE.md
The root `CLAUDE.md` describes a TanStack Start / Bun / Drizzle stack that does **not** match this repo (Astro + Tailwind, npm, content collections). It looks like a generic template carried over from another project. Worth either tailoring it to this Astro project or removing it, since following it here would be actively misleading. Left it untouched in this PR.

https://claude.ai/code/session_01TAfyEwtWxjo9GXatBGWLXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAfyEwtWxjo9GXatBGWLXU)_