### PR TITLE
feat(ui): interactive motion layer for a stronger first impression

### DIFF
--- a/src/components/CallToAction.astro
+++ b/src/components/CallToAction.astro
@@ -9,13 +9,13 @@ interface Props {
 const { href, variant = 'primary', external = false, class: className } = Astro.props;
 
 const base =
-	'inline-flex items-center justify-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2';
+	'inline-flex items-center justify-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium transition-all duration-200 will-change-transform hover:-translate-y-0.5 active:translate-y-0 focus-visible:outline-2 focus-visible:outline-offset-2';
 
 const variants = {
 	primary:
-		'bg-brand text-on-brand hover:bg-brand-strong shadow-sm shadow-brand/20',
+		'bg-brand text-on-brand hover:bg-brand-strong shadow-sm shadow-brand/20 hover:shadow-lg hover:shadow-brand/30',
 	outline:
-		'border border-line-strong text-ink hover:border-brand hover:text-brand',
+		'border border-line-strong text-ink hover:border-brand hover:text-brand hover:bg-brand-tint',
 	ghost: 'text-muted hover:text-ink hover:bg-elevated',
 };
 

--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -9,12 +9,18 @@ const t = useTranslations(lang);
 
 <section class="mx-auto w-full max-w-6xl px-6">
 	<div
-		class="relative overflow-hidden rounded-card border border-line bg-elevated px-6 py-12 text-center sm:px-12 sm:py-16"
+		data-reveal="scale"
+		class="card-spotlight relative overflow-hidden rounded-card border border-line bg-elevated px-6 py-12 text-center sm:px-12 sm:py-16"
 	>
-		<div class="pointer-events-none absolute inset-0 -z-10 bg-grid opacity-40"></div>
-		<h2 class="text-2xl font-semibold sm:text-3xl">{t('contact.title')}</h2>
-		<p class="mx-auto mt-3 max-w-md text-muted">{t('contact.body')}</p>
-		<div class="mt-7 flex flex-wrap justify-center gap-3">
+		<div class="pointer-events-none absolute inset-0 z-0 bg-grid opacity-40"></div>
+		<div
+			class="aurora-blob left-1/2 top-0 z-0 h-64 w-64 -translate-x-1/2"
+			style="background: radial-gradient(circle, var(--color-brand-tint), transparent 70%);"
+		>
+		</div>
+		<h2 class="relative z-10 text-2xl font-semibold sm:text-3xl">{t('contact.title')}</h2>
+		<p class="relative z-10 mx-auto mt-3 max-w-md text-muted">{t('contact.body')}</p>
+		<div class="relative z-10 mt-7 flex flex-wrap justify-center gap-3">
 			<CallToAction href="mailto:contact@pd-portfolio.net">
 				<Icon name="lucide:send" class="h-4 w-4" />
 				{t('contact.send')}

--- a/src/components/HeroBackground.astro
+++ b/src/components/HeroBackground.astro
@@ -1,0 +1,233 @@
+---
+// Interactive network-constellation canvas that sits behind the hero.
+// Nodes drift like a living topology, link up when they are close, and lean
+// toward the cursor so the whole "network" feels alive. Everything is theme
+// aware (it re-reads the brand colors when the theme flips) and it does not
+// run at all under prefers-reduced-motion. It is purely decorative, so it is
+// aria-hidden and pointer-events-none.
+---
+
+<div class="pointer-events-none absolute inset-0 -z-10 overflow-hidden" aria-hidden="true">
+	<!-- Ambient aurora blobs behind the constellation for depth. -->
+	<div
+		class="aurora-blob left-[8%] top-[-6%] h-72 w-72"
+		style="background: radial-gradient(circle, var(--color-brand-tint), transparent 70%);"
+	>
+	</div>
+	<div
+		class="aurora-blob right-[6%] top-[14%] h-80 w-80"
+		style="background: radial-gradient(circle, color-mix(in oklab, var(--color-brand-soft) 18%, transparent), transparent 70%); animation-delay: -7s;"
+	>
+	</div>
+
+	<canvas data-hero-canvas class="h-full w-full opacity-90"></canvas>
+
+	<!-- Fade the canvas into the page toward the bottom edge. -->
+	<div
+		class="absolute inset-x-0 bottom-0 h-40 bg-[linear-gradient(to_top,var(--color-canvas),transparent)]"
+	>
+	</div>
+</div>
+
+<script>
+	type Node = { x: number; y: number; vx: number; vy: number; r: number; pulse: number };
+
+	const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+	const canvas = document.querySelector<HTMLCanvasElement>('[data-hero-canvas]');
+
+	if (canvas && !reduce) {
+		const ctx = canvas.getContext('2d', { alpha: true })!;
+		const root = document.documentElement;
+
+		// Read a CSS custom property and turn it into an rgba() string. The brand
+		// tokens are plain hex, so we parse them and re-emit with the wanted alpha.
+		const readColor = (name: string) => {
+			const raw = getComputedStyle(root).getPropertyValue(name).trim();
+			const hex = raw.replace('#', '');
+			const full =
+				hex.length === 3
+					? hex
+							.split('')
+							.map((c) => c + c)
+							.join('')
+					: hex;
+			const n = parseInt(full || '1f7ae0', 16);
+			return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+		};
+
+		let brand = readColor('--color-brand');
+		let soft = readColor('--color-brand-soft');
+		const refreshColors = () => {
+			brand = readColor('--color-brand');
+			soft = readColor('--color-brand-soft');
+		};
+
+		let width = 0;
+		let height = 0;
+		let dpr = 1;
+		let nodes: Node[] = [];
+		const pointer = { x: -9999, y: -9999, active: false };
+		const linkDist = 130;
+
+		const resize = () => {
+			const rect = canvas.parentElement!.getBoundingClientRect();
+			width = rect.width;
+			height = rect.height;
+			dpr = Math.min(window.devicePixelRatio || 1, 2);
+			canvas.width = Math.floor(width * dpr);
+			canvas.height = Math.floor(height * dpr);
+			ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+			// Node count scales with area but stays capped for performance.
+			const count = Math.min(96, Math.max(28, Math.round((width * height) / 15000)));
+			nodes = Array.from({ length: count }, () => ({
+				x: Math.random() * width,
+				y: Math.random() * height,
+				vx: (Math.random() - 0.5) * 0.32,
+				vy: (Math.random() - 0.5) * 0.32,
+				r: Math.random() * 1.6 + 1,
+				pulse: Math.random() * Math.PI * 2,
+			}));
+		};
+
+		const rgba = (c: { r: number; g: number; b: number }, a: number) =>
+			`rgba(${c.r},${c.g},${c.b},${a})`;
+
+		const step = () => {
+			ctx.clearRect(0, 0, width, height);
+
+			for (const n of nodes) {
+				// Gentle drift with edge wrap.
+				n.x += n.vx;
+				n.y += n.vy;
+				if (n.x < -20) n.x = width + 20;
+				if (n.x > width + 20) n.x = -20;
+				if (n.y < -20) n.y = height + 20;
+				if (n.y > height + 20) n.y = -20;
+
+				// Soft attraction toward the cursor so the mesh leans in.
+				if (pointer.active) {
+					const dx = pointer.x - n.x;
+					const dy = pointer.y - n.y;
+					const d2 = dx * dx + dy * dy;
+					if (d2 < 200 * 200 && d2 > 1) {
+						const f = (1 - Math.sqrt(d2) / 200) * 0.6;
+						n.x += (dx / Math.sqrt(d2)) * f;
+						n.y += (dy / Math.sqrt(d2)) * f;
+					}
+				}
+				n.pulse += 0.02;
+			}
+
+			// Links between nearby nodes.
+			for (let i = 0; i < nodes.length; i++) {
+				const a = nodes[i];
+				for (let j = i + 1; j < nodes.length; j++) {
+					const b = nodes[j];
+					const dx = a.x - b.x;
+					const dy = a.y - b.y;
+					const dist = Math.hypot(dx, dy);
+					if (dist < linkDist) {
+						const alpha = (1 - dist / linkDist) * 0.5;
+						ctx.strokeStyle = rgba(brand, alpha);
+						ctx.lineWidth = 1;
+						ctx.beginPath();
+						ctx.moveTo(a.x, a.y);
+						ctx.lineTo(b.x, b.y);
+						ctx.stroke();
+					}
+				}
+
+				// Links from the cursor to nearby nodes, brighter.
+				if (pointer.active) {
+					const dx = a.x - pointer.x;
+					const dy = a.y - pointer.y;
+					const dist = Math.hypot(dx, dy);
+					if (dist < 200) {
+						ctx.strokeStyle = rgba(soft, (1 - dist / 200) * 0.55);
+						ctx.lineWidth = 1;
+						ctx.beginPath();
+						ctx.moveTo(a.x, a.y);
+						ctx.lineTo(pointer.x, pointer.y);
+						ctx.stroke();
+					}
+				}
+			}
+
+			// Node dots with a slow breathing glow.
+			for (const n of nodes) {
+				const glow = (Math.sin(n.pulse) + 1) / 2;
+				ctx.beginPath();
+				ctx.arc(n.x, n.y, n.r + glow * 0.8, 0, Math.PI * 2);
+				ctx.fillStyle = rgba(brand, 0.55 + glow * 0.35);
+				ctx.fill();
+			}
+
+			// A brighter marker at the cursor itself.
+			if (pointer.active) {
+				ctx.beginPath();
+				ctx.arc(pointer.x, pointer.y, 3, 0, Math.PI * 2);
+				ctx.fillStyle = rgba(soft, 0.9);
+				ctx.fill();
+			}
+		};
+
+		let raf = 0;
+		let running = false;
+		const loop = () => {
+			step();
+			raf = requestAnimationFrame(loop);
+		};
+		const start = () => {
+			if (running) return;
+			running = true;
+			loop();
+		};
+		const stop = () => {
+			running = false;
+			cancelAnimationFrame(raf);
+		};
+
+		// Track the pointer relative to the canvas.
+		const onMove = (e: PointerEvent) => {
+			const rect = canvas.getBoundingClientRect();
+			const x = e.clientX - rect.left;
+			const y = e.clientY - rect.top;
+			pointer.active = x >= 0 && y >= 0 && x <= rect.width && y <= rect.height;
+			pointer.x = x;
+			pointer.y = y;
+		};
+		window.addEventListener('pointermove', onMove, { passive: true });
+		window.addEventListener('pointerleave', () => (pointer.active = false));
+
+		// Only animate while the hero is on screen and the tab is visible.
+		const io = new IntersectionObserver(
+			([entry]) => {
+				if (entry.isIntersecting && !document.hidden) start();
+				else stop();
+			},
+			{ threshold: 0.01 }
+		);
+		io.observe(canvas);
+
+		document.addEventListener('visibilitychange', () => {
+			if (document.hidden) stop();
+			else start();
+		});
+
+		// Recolor when the theme toggles.
+		new MutationObserver(refreshColors).observe(root, {
+			attributes: true,
+			attributeFilter: ['class'],
+		});
+
+		let resizeTimer = 0;
+		window.addEventListener('resize', () => {
+			window.clearTimeout(resizeTimer);
+			resizeTimer = window.setTimeout(resize, 150);
+		});
+
+		resize();
+		start();
+	}
+</script>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -26,7 +26,10 @@ const isActive = (href: string) => {
 };
 ---
 
-<header class="sticky top-0 z-50 border-b border-line bg-canvas/80 backdrop-blur-md">
+<header
+	data-nav
+	class="sticky top-0 z-50 border-b border-transparent transition-all duration-300 [&.is-scrolled]:border-line [&.is-scrolled]:bg-canvas/80 [&.is-scrolled]:backdrop-blur-md [&.is-scrolled]:shadow-[0_8px_30px_-20px_rgba(0,0,0,0.4)]"
+>
 	<nav class="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
 		<a href={localizePath('/', lang)} class="font-display text-lg font-bold tracking-tight">
 			<span class="text-gradient">Paul Dresch</span>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -6,9 +6,10 @@ import { getLangFromUrl, useTranslations, localizePath } from '../i18n/utils';
 
 interface Props {
 	project: Project;
+	index?: number;
 }
 
-const { project } = Astro.props;
+const { project, index = 0 } = Astro.props;
 const { title, description, stack, repoUrl, liveUrl, status, icon } = project.data;
 
 const lang = getLangFromUrl(Astro.url);
@@ -19,12 +20,17 @@ const statusLabel: Record<string, string> = {
 	wip: t('status.wip'),
 	archived: t('status.archived'),
 };
+
+// Stagger the reveal of cards within a grid row.
+const revealDelay = `${(index % 3) * 90}ms`;
 ---
 
 <article
-	class="group relative flex flex-col overflow-hidden rounded-card border border-line bg-surface transition-all duration-200 hover:-translate-y-1 hover:border-line-strong hover:shadow-xl hover:ring-1 hover:ring-brand/15"
+	data-reveal="scale"
+	style={`--reveal-delay: ${revealDelay}`}
+	class="card-spotlight group relative flex flex-col overflow-hidden rounded-card border border-line bg-surface hover:border-line-strong"
 >
-	<div class="relative aspect-[16/9] overflow-hidden border-b border-line bg-elevated">
+	<div class="relative z-10 aspect-[16/9] overflow-hidden border-b border-line bg-elevated">
 		<div
 			class="flex h-full w-full items-center justify-center bg-[linear-gradient(135deg,var(--color-brand-tint),transparent)]"
 		>
@@ -48,7 +54,7 @@ const statusLabel: Record<string, string> = {
 		}
 	</div>
 
-	<div class="flex flex-1 flex-col gap-3 p-5">
+	<div class="relative z-10 flex flex-1 flex-col gap-3 p-5">
 		<h3 class="text-lg font-semibold text-ink">
 			<a href={href} class="before:absolute before:inset-0 before:content-['']">
 				{title}

--- a/src/components/Section.astro
+++ b/src/components/Section.astro
@@ -3,15 +3,17 @@ interface Props {
 	title?: string;
 	eyebrow?: string;
 	class?: string;
+	id?: string;
+	reveal?: boolean;
 }
 
-const { title, eyebrow, class: className } = Astro.props;
+const { title, eyebrow, class: className, id, reveal = false } = Astro.props;
 ---
 
-<section class:list={['mx-auto w-full max-w-6xl px-6', className]}>
+<section id={id} class:list={['mx-auto w-full max-w-6xl px-6', className]}>
 	{
 		(eyebrow || title) && (
-			<header class="mb-8 flex flex-col gap-2 sm:mb-10">
+			<header class="mb-8 flex flex-col gap-2 sm:mb-10" data-reveal={reveal ? '' : undefined}>
 				{eyebrow && (
 					<span class="font-mono text-sm uppercase tracking-[0.2em] text-brand">{eyebrow}</span>
 				)}

--- a/src/components/SiteInteractions.astro
+++ b/src/components/SiteInteractions.astro
@@ -1,0 +1,103 @@
+---
+// Site-wide client interactions, mounted once from the base layout:
+//   - scroll reveals for [data-reveal]
+//   - cursor-follow spotlight + 3D tilt for .card-spotlight
+//   - count-up for [data-count]
+//   - nav elevation once the page is scrolled
+// All of it no-ops cleanly under prefers-reduced-motion.
+---
+
+<script>
+	const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+	// --- Scroll reveals -------------------------------------------------------
+	const revealEls = Array.from(document.querySelectorAll<HTMLElement>('[data-reveal]'));
+	if (revealEls.length) {
+		if (reduce) {
+			revealEls.forEach((el) => el.classList.add('is-visible'));
+		} else {
+			const io = new IntersectionObserver(
+				(entries, obs) => {
+					for (const entry of entries) {
+						if (!entry.isIntersecting) continue;
+						entry.target.classList.add('is-visible');
+						obs.unobserve(entry.target);
+					}
+				},
+				{ threshold: 0.12, rootMargin: '0px 0px -8% 0px' }
+			);
+			revealEls.forEach((el) => io.observe(el));
+		}
+	}
+
+	// --- Spotlight + tilt cards ----------------------------------------------
+	if (!reduce && !window.matchMedia('(pointer: coarse)').matches) {
+		const cards = document.querySelectorAll<HTMLElement>('.card-spotlight');
+		cards.forEach((card) => {
+			let frame = 0;
+			const onMove = (e: PointerEvent) => {
+				if (frame) return;
+				frame = requestAnimationFrame(() => {
+					frame = 0;
+					const rect = card.getBoundingClientRect();
+					const px = (e.clientX - rect.left) / rect.width;
+					const py = (e.clientY - rect.top) / rect.height;
+					card.style.setProperty('--mx', `${px * 100}%`);
+					card.style.setProperty('--my', `${py * 100}%`);
+					// Tilt is small and inverted so the card leans toward the cursor.
+					const max = 5;
+					card.style.setProperty('--ry', `${(px - 0.5) * max * 2}deg`);
+					card.style.setProperty('--rx', `${(0.5 - py) * max * 2}deg`);
+				});
+			};
+			const reset = () => {
+				card.style.setProperty('--rx', '0deg');
+				card.style.setProperty('--ry', '0deg');
+			};
+			card.addEventListener('pointermove', onMove);
+			card.addEventListener('pointerleave', reset);
+		});
+	}
+
+	// --- Count-up stats -------------------------------------------------------
+	const counters = document.querySelectorAll<HTMLElement>('[data-count]');
+	if (counters.length) {
+		const run = (el: HTMLElement) => {
+			const target = Number(el.dataset.count || '0');
+			const suffix = el.dataset.suffix || '';
+			if (reduce) {
+				el.textContent = `${target}${suffix}`;
+				return;
+			}
+			const dur = 1100;
+			const t0 = performance.now();
+			const tick = (now: number) => {
+				const p = Math.min((now - t0) / dur, 1);
+				// easeOutCubic
+				const eased = 1 - Math.pow(1 - p, 3);
+				el.textContent = `${Math.round(target * eased)}${suffix}`;
+				if (p < 1) requestAnimationFrame(tick);
+			};
+			requestAnimationFrame(tick);
+		};
+		const io = new IntersectionObserver(
+			(entries, obs) => {
+				for (const entry of entries) {
+					if (!entry.isIntersecting) continue;
+					run(entry.target as HTMLElement);
+					obs.unobserve(entry.target);
+				}
+			},
+			{ threshold: 0.6 }
+		);
+		counters.forEach((el) => io.observe(el));
+	}
+
+	// --- Nav elevation on scroll ---------------------------------------------
+	const nav = document.querySelector<HTMLElement>('[data-nav]');
+	if (nav) {
+		const onScroll = () => nav.classList.toggle('is-scrolled', window.scrollY > 8);
+		onScroll();
+		window.addEventListener('scroll', onScroll, { passive: true });
+	}
+</script>

--- a/src/components/pages/AboutPage.astro
+++ b/src/components/pages/AboutPage.astro
@@ -11,7 +11,7 @@ const { skills } = getContent(lang);
 ---
 
 <BaseLayout title={t('about.meta.title')} description={t('about.meta.desc')}>
-	<div class="mx-auto max-w-6xl px-6 pt-20 sm:pt-28">
+	<div data-reveal class="mx-auto max-w-6xl px-6 pt-20 sm:pt-28">
 		<Hero
 			eyebrow={t('about.hero.eyebrow')}
 			title={t('about.hero.title')}
@@ -22,6 +22,7 @@ const { skills } = getContent(lang);
 
 	<div class="mx-auto mt-12 grid max-w-6xl gap-10 px-6 lg:grid-cols-[1.4fr_1fr]">
 		<div
+			data-reveal
 			class="prose prose-lg max-w-none dark:prose-invert prose-headings:font-display prose-a:text-brand"
 		>
 			<p>{t('about.bodyP1')}</p>
@@ -29,25 +30,34 @@ const { skills } = getContent(lang);
 		</div>
 		<!-- Branded panel, consistent with the project cards' icon treatment. -->
 		<div
-			class="relative flex min-h-56 flex-col justify-end overflow-hidden rounded-card border border-line bg-[linear-gradient(135deg,var(--color-brand-tint),transparent)] p-6"
+			data-reveal="right"
+			class="card-spotlight relative flex min-h-56 flex-col justify-end overflow-hidden rounded-card border border-line bg-[linear-gradient(135deg,var(--color-brand-tint),transparent)] p-6"
 		>
-			<div class="pointer-events-none absolute inset-0 -z-0 bg-grid opacity-30"></div>
-			<Icon name="lucide:server" class="relative h-14 w-14 text-brand" />
-			<p class="relative mt-4 font-mono text-sm text-muted">{t('about.imageLabel')}</p>
+			<div class="pointer-events-none absolute inset-0 z-0 bg-grid opacity-30"></div>
+			<div
+				class="pointer-events-none absolute inset-0 z-0 bg-[radial-gradient(70%_60%_at_50%_120%,var(--color-brand-tint),transparent)]"
+			>
+			</div>
+			<Icon name="lucide:server" class="relative z-10 h-14 w-14 animate-[float-slow_6s_ease-in-out_infinite] text-brand" />
+			<p class="relative z-10 mt-4 font-mono text-sm text-muted">{t('about.imageLabel')}</p>
 		</div>
 	</div>
 
 	<div class="mx-auto mt-16 max-w-6xl px-6">
-		<h2 class="text-2xl font-semibold sm:text-3xl">{t('about.skillsTitle')}</h2>
+		<h2 data-reveal class="text-2xl font-semibold sm:text-3xl">{t('about.skillsTitle')}</h2>
 		<div class="mt-8 grid gap-5 sm:grid-cols-2">
 			{
-				skills.map((s) => (
-					<div class="rounded-card border border-line bg-surface p-6">
-						<div class="flex h-11 w-11 items-center justify-center rounded-lg bg-brand-tint text-brand">
+				skills.map((s, i) => (
+					<div
+						data-reveal="scale"
+						style={`--reveal-delay: ${(i % 2) * 90}ms`}
+						class="card-spotlight group relative overflow-hidden rounded-card border border-line bg-surface p-6"
+					>
+						<div class="relative z-10 flex h-11 w-11 items-center justify-center rounded-lg bg-brand-tint text-brand transition-transform duration-200 group-hover:scale-110">
 							<Icon name={s.icon} class="h-5 w-5" />
 						</div>
-						<h3 class="mt-4 text-lg font-semibold text-ink">{s.title}</h3>
-						<p class="mt-2 text-sm text-muted">{s.body}</p>
+						<h3 class="relative z-10 mt-4 text-lg font-semibold text-ink">{s.title}</h3>
+						<p class="relative z-10 mt-2 text-sm text-muted">{s.body}</p>
 					</div>
 				))
 			}

--- a/src/components/pages/HomePage.astro
+++ b/src/components/pages/HomePage.astro
@@ -5,6 +5,7 @@ import Section from '../Section.astro';
 import ProjectCard from '../ProjectCard.astro';
 import ContactCTA from '../ContactCTA.astro';
 import CallToAction from '../CallToAction.astro';
+import HeroBackground from '../HeroBackground.astro';
 import { getProjects } from '../../lib/projects';
 import { getLangFromUrl, useTranslations, getContent, localizePath } from '../../i18n/utils';
 
@@ -15,50 +16,124 @@ const { focus } = getContent(lang);
 const allProjects = await getProjects(lang);
 const featured = allProjects.filter((p) => p.data.featured);
 const projects = (featured.length ? featured : allProjects).slice(0, 6);
+
+// Honest, derived numbers for the hero stat strip. Nothing is hardcoded that
+// would drift out of sync with the actual project content.
+const shippedCount = allProjects.filter((p) => p.data.status === 'shipped').length;
+const stackCount = new Set(allProjects.flatMap((p) => p.data.stack)).size;
+const stats = [
+	{ value: allProjects.length, suffix: '', label: lang === 'de' ? 'Projekte' : 'Projects' },
+	{ value: shippedCount, suffix: '', label: lang === 'de' ? 'Ausgeliefert' : 'Shipped' },
+	{ value: stackCount, suffix: '', label: lang === 'de' ? 'Technologien' : 'Technologies' },
+];
+const availableLabel =
+	lang === 'de' ? 'Verfügbar für neue Projekte' : 'Available for new work';
 ---
 
 <BaseLayout title={t('home.meta.title')} description={t('home.meta.desc')}>
 	<!-- Hero -->
-	<section class="mx-auto max-w-6xl px-6 pb-16 pt-20 sm:pt-28">
-		<p class="font-mono text-sm uppercase tracking-[0.2em] text-brand">
-			{t('home.hero.eyebrow')}
-		</p>
-		<h1 class="mt-4 max-w-4xl text-4xl font-semibold leading-[1.1] sm:text-6xl">
-			{t('home.hero.titleLead')}<span class="text-gradient">{t('home.hero.titleHighlight')}</span
-			>{t('home.hero.titleTail')}
-		</h1>
-		<p class="mt-6 max-w-2xl text-lg text-muted">{t('home.hero.subtitle')}</p>
-		<div class="mt-8 flex flex-wrap gap-3">
-			<CallToAction href={localizePath('/projects/', lang)}>
-				{t('cta.viewProjects')}
-				<Icon name="lucide:arrow-right" class="h-4 w-4" />
-			</CallToAction>
-			<CallToAction href="https://github.com/Paul1404" variant="outline" external>
-				<Icon name="lucide:github" class="h-4 w-4" />
-				{t('cta.github')}
-			</CallToAction>
-			<CallToAction href="mailto:contact@pd-portfolio.net" variant="ghost">
-				<Icon name="lucide:mail" class="h-4 w-4" />
-				{t('cta.contact')}
-			</CallToAction>
+	<section class="relative isolate min-h-[88vh] overflow-hidden">
+		<HeroBackground />
+
+		<div class="mx-auto flex max-w-6xl flex-col px-6 pb-20 pt-24 sm:pt-32">
+			<p
+				data-reveal
+				class="inline-flex items-center gap-2 self-start rounded-full border border-line bg-surface/70 px-3 py-1 font-mono text-xs uppercase tracking-[0.2em] text-brand backdrop-blur"
+			>
+				<span class="live-dot inline-block h-1.5 w-1.5 rounded-full bg-emerald-500 text-emerald-500"></span>
+				{availableLabel}
+			</p>
+
+			<h1
+				data-reveal
+				style="--reveal-delay: 80ms"
+				class="mt-6 max-w-4xl text-4xl font-semibold leading-[1.08] sm:text-6xl"
+			>
+				{t('home.hero.titleLead')}<span class="text-gradient-flow"
+					>{t('home.hero.titleHighlight')}</span
+				>{t('home.hero.titleTail')}
+			</h1>
+
+			<p data-reveal style="--reveal-delay: 160ms" class="mt-6 max-w-2xl text-lg text-muted">
+				{t('home.hero.subtitle')}
+			</p>
+
+			<div
+				data-reveal
+				style="--reveal-delay: 240ms"
+				class="mt-8 flex flex-wrap gap-3"
+			>
+				<CallToAction href={localizePath('/projects/', lang)} class="btn-sheen">
+					<span class="sheen"></span>
+					{t('cta.viewProjects')}
+					<Icon name="lucide:arrow-right" class="h-4 w-4" />
+				</CallToAction>
+				<CallToAction href="https://github.com/Paul1404" variant="outline" external>
+					<Icon name="lucide:github" class="h-4 w-4" />
+					{t('cta.github')}
+				</CallToAction>
+				<CallToAction href="mailto:contact@pd-portfolio.net" variant="ghost">
+					<Icon name="lucide:mail" class="h-4 w-4" />
+					{t('cta.contact')}
+				</CallToAction>
+			</div>
+
+			<div data-reveal style="--reveal-delay: 320ms" class="mt-10 flex flex-wrap gap-2">
+				{
+					focus.map((f) => (
+						<span class="chip-float rounded-full border border-line bg-surface/70 px-3 py-1 font-mono text-xs text-muted backdrop-blur">
+							{f}
+						</span>
+					))
+				}
+			</div>
+
+			<!-- Live stat strip with count-up. All numbers derived from content. -->
+			<dl
+				data-reveal
+				style="--reveal-delay: 400ms"
+				class="mt-12 grid max-w-xl grid-cols-3 gap-px overflow-hidden rounded-card border border-line bg-line"
+			>
+				{
+					stats.map((s) => (
+						<div class="flex flex-col gap-1 bg-surface/80 px-5 py-4 backdrop-blur">
+							<dt class="sr-only">{s.label}</dt>
+							<dd
+								data-count={s.value}
+								data-suffix={s.suffix}
+								class="font-display text-3xl font-bold text-ink"
+							>
+								0{s.suffix}
+							</dd>
+							<span class="text-xs uppercase tracking-wider text-subtle">{s.label}</span>
+						</div>
+					))
+				}
+			</dl>
 		</div>
-		<div class="mt-10 flex flex-wrap gap-2">
-			{
-				focus.map((f) => (
-					<span class="rounded-full border border-line bg-surface px-3 py-1 font-mono text-xs text-muted">
-						{f}
-					</span>
-				))
-			}
-		</div>
+
+		<!-- Scroll cue. -->
+		<a
+			href="#work"
+			class="absolute bottom-6 left-1/2 hidden -translate-x-1/2 flex-col items-center gap-1 text-subtle transition-colors hover:text-brand sm:flex"
+		>
+			<span class="text-[10px] uppercase tracking-[0.2em]">{t('home.featured.eyebrow')}</span>
+			<Icon name="lucide:chevron-down" class="scroll-cue h-5 w-5" />
+		</a>
 	</section>
 
 	<!-- Featured projects -->
-	<Section eyebrow={t('home.featured.eyebrow')} title={t('home.featured.title')} class="py-8">
+	<Section
+		id="work"
+		eyebrow={t('home.featured.eyebrow')}
+		title={t('home.featured.title')}
+		class="scroll-mt-24 py-8"
+		reveal
+	>
 		<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-			{projects.map((project) => <ProjectCard project={project} />)}
+			{projects.map((project, i) => <ProjectCard project={project} index={i} />)}
 		</div>
-		<div class="mt-10 flex justify-center">
+		<div data-reveal class="mt-10 flex justify-center">
 			<CallToAction href={localizePath('/projects/', lang)} variant="outline">
 				{t('cta.seeAll')}
 				<Icon name="lucide:arrow-right" class="h-4 w-4" />

--- a/src/components/pages/ProjectsPage.astro
+++ b/src/components/pages/ProjectsPage.astro
@@ -12,7 +12,7 @@ const projects = await getProjects(lang);
 ---
 
 <BaseLayout title={t('projects.meta.title')} description={t('projects.meta.desc')}>
-	<div class="mx-auto max-w-6xl px-6 pt-20 sm:pt-28">
+	<div data-reveal class="mx-auto max-w-6xl px-6 pt-20 sm:pt-28">
 		<Hero
 			eyebrow={t('projects.hero.eyebrow')}
 			title={t('projects.hero.title')}
@@ -23,7 +23,7 @@ const projects = await getProjects(lang);
 
 	<div class="mx-auto mt-12 max-w-6xl px-6">
 		<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-			{projects.map((project) => <ProjectCard project={project} />)}
+			{projects.map((project, i) => <ProjectCard project={project} index={i} />)}
 		</div>
 	</div>
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import MainHead from '../components/MainHead.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
+import SiteInteractions from '../components/SiteInteractions.astro';
 import { getLangFromUrl } from '../i18n/utils';
 
 interface Props {
@@ -17,11 +18,25 @@ const lang = getLangFromUrl(Astro.url);
 	<head>
 		<MainHead title={title} description={description} />
 		<link rel="sitemap" href="/sitemap-index.xml" />
+		<!-- Without JS the IntersectionObserver never runs, so reveal everything. -->
+		<noscript>
+			<style>
+				[data-reveal] {
+					opacity: 1 !important;
+					transform: none !important;
+				}
+			</style>
+		</noscript>
 	</head>
 	<body class="flex min-h-screen flex-col">
 		<!-- Ambient background: subtle brand glow at the top, fading into the canvas. -->
 		<div
 			class="pointer-events-none fixed inset-x-0 top-0 -z-10 h-[60vh] bg-[radial-gradient(60%_100%_at_50%_0%,var(--color-brand-tint),transparent)]"
+		>
+		</div>
+		<!-- Faint fixed grid that gives the whole canvas a touch of texture. -->
+		<div
+			class="pointer-events-none fixed inset-0 -z-10 bg-grid opacity-[0.035] [mask-image:radial-gradient(70%_60%_at_50%_0%,black,transparent)]"
 		>
 		</div>
 
@@ -30,5 +45,6 @@ const lang = getLangFromUrl(Astro.url);
 			<slot />
 		</main>
 		<Footer />
+		<SiteInteractions />
 	</body>
 </html>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -96,3 +96,212 @@
     linear-gradient(to bottom, var(--color-line) 1px, transparent 1px);
   background-size: 56px 56px;
 }
+
+/* =====================================================================
+   Motion layer. Everything below powers the "wow" without new deps:
+   scroll reveals, a flowing brand gradient, cursor-follow spotlight +
+   tilt cards, and a few ambient animations. All of it collapses to a
+   static, accessible state under prefers-reduced-motion.
+   ===================================================================== */
+
+@keyframes gradient-pan {
+  0%   { background-position: 0% 50%; }
+  50%  { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+@keyframes float-slow {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-10px); }
+}
+
+@keyframes pulse-ring {
+  0%   { transform: scale(0.9); opacity: 0.7; }
+  70%  { transform: scale(1.8); opacity: 0; }
+  100% { transform: scale(1.8); opacity: 0; }
+}
+
+@keyframes aurora-drift {
+  0%   { transform: translate3d(-4%, -2%, 0) scale(1.05); }
+  50%  { transform: translate3d(4%, 3%, 0) scale(1.15); }
+  100% { transform: translate3d(-4%, -2%, 0) scale(1.05); }
+}
+
+@keyframes sheen {
+  0%   { transform: translateX(-120%) skewX(-12deg); }
+  60%, 100% { transform: translateX(220%) skewX(-12deg); }
+}
+
+@keyframes bob {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(6px); }
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0; }
+}
+
+/* Flowing version of the brand gradient. Used on the hero highlight word. */
+@utility text-gradient-flow {
+  background-image: linear-gradient(
+    100deg,
+    var(--color-brand),
+    var(--color-brand-soft),
+    var(--color-brand-strong),
+    var(--color-brand-soft),
+    var(--color-brand)
+  );
+  background-size: 250% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: gradient-pan 8s ease-in-out infinite;
+}
+
+/* Animated brand underline that grows in once revealed. */
+@utility brand-underline {
+  position: relative;
+}
+
+/* Scroll-reveal primitives. Elements tagged with data-reveal start hidden and
+   animate to their resting state when an IntersectionObserver adds .is-visible.
+   data-reveal="left|right|scale" pick the entrance vector. */
+[data-reveal] {
+  opacity: 0;
+  transform: translateY(22px);
+  transition:
+    opacity 0.7s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.7s cubic-bezier(0.22, 1, 0.36, 1);
+  transition-delay: var(--reveal-delay, 0ms);
+  will-change: opacity, transform;
+}
+[data-reveal="left"]  { transform: translateX(-26px); }
+[data-reveal="right"] { transform: translateX(26px); }
+[data-reveal="scale"] { transform: scale(0.94); }
+[data-reveal].is-visible {
+  opacity: 1;
+  transform: none;
+}
+
+/* Cursor-follow spotlight + tilt card. JS sets --mx/--my (pointer position as a
+   percentage) and --rx/--ry (tilt angles). The ::before paints a soft brand
+   glow that tracks the cursor; the whole card lifts and tilts on hover. */
+.card-spotlight {
+  --mx: 50%;
+  --my: 50%;
+  --rx: 0deg;
+  --ry: 0deg;
+  transform: perspective(900px) rotateX(var(--rx)) rotateY(var(--ry)) translateZ(0);
+  transition: transform 0.25s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.3s ease,
+    border-color 0.3s ease;
+}
+.card-spotlight::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  background: radial-gradient(
+    340px circle at var(--mx) var(--my),
+    color-mix(in oklab, var(--color-brand) 22%, transparent),
+    transparent 60%
+  );
+}
+.card-spotlight:hover::before { opacity: 1; }
+.card-spotlight:hover {
+  box-shadow: 0 24px 60px -28px color-mix(in oklab, var(--color-brand) 60%, transparent);
+}
+
+/* Thin animated gradient hairline that runs along the top edge of a card. */
+.card-spotlight::after {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 1px;
+  z-index: 2;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in oklab, var(--color-brand) 70%, transparent) calc(var(--mx)),
+    transparent
+  );
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+.card-spotlight:hover::after { opacity: 1; }
+
+/* Button sheen sweep, triggered on hover of .btn-sheen. */
+.btn-sheen { position: relative; overflow: hidden; }
+.btn-sheen > span.sheen {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 40%;
+  height: 100%;
+  pointer-events: none;
+  background: linear-gradient(
+    100deg,
+    transparent,
+    color-mix(in oklab, white 55%, transparent),
+    transparent
+  );
+  opacity: 0;
+}
+.btn-sheen:hover > span.sheen {
+  opacity: 0.8;
+  animation: sheen 0.9s ease;
+}
+
+/* Soft floating tech chip. */
+.chip-float { transition: transform 0.2s ease, border-color 0.2s ease, color 0.2s ease; }
+.chip-float:hover {
+  transform: translateY(-2px);
+  border-color: var(--color-brand);
+  color: var(--color-ink);
+}
+
+/* Animated multi-blob aurora used behind the hero. */
+.aurora-blob {
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(60px);
+  opacity: 0.55;
+  animation: aurora-drift 18s ease-in-out infinite;
+  will-change: transform;
+}
+
+/* Pulsing "live" ring used on the status dot. */
+.live-dot { position: relative; }
+.live-dot::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: currentColor;
+  animation: pulse-ring 2.4s ease-out infinite;
+}
+
+.scroll-cue { animation: bob 1.8s ease-in-out infinite; }
+.caret { animation: blink 1.1s step-end infinite; }
+
+/* Honor reduced-motion: drop all decorative motion and reveal everything. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+  [data-reveal] {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+  .card-spotlight {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
## What this does

Adds a cohesive, dependency-free motion layer so the portfolio makes a real first impression, while keeping the existing clean aesthetic and the blue/cyan brand.

### The centerpiece: interactive network constellation
A canvas behind the hero renders an animated network topology (thematically fitting for an infra/cloud engineer). Nodes drift, link up when close, and the whole mesh leans toward the cursor. It is theme aware (recolors when the theme toggles), pauses when off-screen or the tab is hidden, caps DPR for performance, and does not run at all under `prefers-reduced-motion`.

### Everything else
- **Hero rework**: staggered entrance, a flowing brand gradient on the highlight word, an availability badge with a live pulse, and a stat strip with count-up animation. The stat numbers (total projects, shipped, technologies) are derived from the project content, so they never drift out of sync.
- **Spotlight + 3D tilt cards**: project and skill cards get a cursor-follow brand glow, a subtle tilt, an animated top hairline, and a soft lift shadow.
- **Scroll reveals**: sections and cards fade and slide in via `IntersectionObserver`, with row staggering.
- **Polish**: nav elevates once scrolled, primary buttons get a lift plus sheen sweep, focus chips float on hover, and the contact CTA and about panel gain animated aurora glows.

## Accessibility and resilience
- A global `prefers-reduced-motion` block disables all decorative motion and forces revealed content visible.
- Touch and coarse pointers skip the tilt/spotlight pointer work.
- A `<noscript>` fallback reveals all content if JavaScript is unavailable.

## Implementation notes
- No new dependencies. All vanilla JS in Astro `<script>` islands plus CSS keyframes/utilities in `tailwind.css`.
- New components: `HeroBackground.astro` (the canvas) and `SiteInteractions.astro` (reveals, tilt, count-up, nav).
- `npm run build` passes; all 50 pages build and the interaction logic is present in the output.

https://claude.ai/code/session_014h2H1ZMzcCCeJS3w8BGzAE

---
_Generated by [Claude Code](https://claude.ai/code/session_014h2H1ZMzcCCeJS3w8BGzAE)_