### PR TITLE
feat(content): add astro-portfolio, svutt and svufo projects

### DIFF
--- a/src/content/projects/de/astro-portfolio.md
+++ b/src/content/projects/de/astro-portfolio.md
@@ -1,0 +1,28 @@
+---
+title: "Dieses Portfolio"
+publishDate: 2026-06-02 00:00:00
+description: "Die Seite, die du gerade ansiehst. Ein statisches, zweisprachiges Portfolio mit Astro, bei dem jedes Projekt eine Markdown-Datei in einer Content Collection ist."
+stack:
+  - Astro
+  - TypeScript
+  - Tailwind CSS
+tags:
+  - Web
+  - Open Source
+repoUrl: https://github.com/Paul1404/astro-portfolio
+liveUrl: https://pd-portfolio.net
+status: shipped
+icon: globe
+---
+
+Eine persönliche Seite muss schnell laden, leicht zu pflegen sein und nicht selbst zum Wartungsprojekt werden. Diese hier ist ein statischer Astro-Build, bei dem ein neues Projekt eine Markdown-Datei bedeutet und nicht das Anfassen von Komponenten.
+
+### Was es macht
+
+- Erzeugt jedes Projekt aus Markdown in einer Content Collection, sodass neue Einträge je eine Datei sind.
+- Liefert Englisch und Deutsch aus derselben Quelle über integriertes i18n-Routing.
+- Bringt ein kleines interaktives Terminal unter `/terminal` mit sowie ein vollständiges Favicon-Set, das aus einer einzigen SVG generiert wird.
+
+### Warum es wichtig ist
+
+Inhalt und Code bleiben getrennt, sodass das Schreiben über ein neues Projekt nie ein Bearbeiten der Seite selbst bedeutet. Sie baut zu reinen statischen Dateien und wird auf Cloudflare Pages deployt.

--- a/src/content/projects/de/svufo.md
+++ b/src/content/projects/de/svufo.md
@@ -1,0 +1,28 @@
+---
+title: "Kassenzählprotokolle"
+publishDate: 2026-05-12 00:00:00
+description: "Eine Web-App, mit der Vereine Kassenzählungen und Ausgaben erfassen und daraus nummerierte PDF-Belege erzeugen, die direkt in die DATEV-Buchhaltung passen."
+stack:
+  - TypeScript
+  - Next.js
+  - PostgreSQL
+tags:
+  - Finanzen
+  - Formulare
+  - Open Source
+repoUrl: https://github.com/Paul1404/svufo
+status: shipped
+icon: banknote
+---
+
+Die Kasse zu zählen und Ausgaben in einer Tabelle zu erfassen funktioniert, bis man einen sauberen, prüffähigen Nachweis braucht. Dieses Projekt ersetzt die Tabelle durch ein geführtes Formular, das ordentliche Belege erzeugt, die für die Buchhaltung bereit sind.
+
+### Was es macht
+
+- Erfasst Kassenzählungen über alle Stückelungen und protokolliert Ausgaben mit konfigurierbaren Mehrwertsteuersätzen.
+- Nummeriert Belege automatisch pro Jahr und erzeugt PDFs mit einer SHA256-Prüfsumme.
+- Hält Korrekturen über einen Storno-Ablauf prüffähig, der den ursprünglichen Datensatz erhält, und exportiert CSV für den Steuerberater.
+
+### Warum es wichtig ist
+
+Der Verein erhält Nachweise, die einer Prüfung standhalten, statt einer Tabelle, der niemand ganz vertraut. Die Ausgabe ist so gebaut, dass sie sich direkt in DATEV hochladen lässt, sodass der Buchungsschritt kurz bleibt.

--- a/src/content/projects/de/svufo.md
+++ b/src/content/projects/de/svufo.md
@@ -1,28 +1,30 @@
 ---
 title: "Kassenzählprotokolle"
 publishDate: 2026-05-12 00:00:00
-description: "Eine Web-App, mit der Vereine Kassenzählungen und Ausgaben erfassen und daraus nummerierte PDF-Belege erzeugen, die direkt in die DATEV-Buchhaltung passen."
+description: "Eine Web-App, mit der ein Vereinskassier Kassenzählungen und Ausgaben erfasst und daraus nummerierte, GoBD-konforme PDF-Belege erzeugt, die sich direkt in DATEV hochladen lassen."
 stack:
   - TypeScript
   - Next.js
   - PostgreSQL
+  - Hono
 tags:
   - Finanzen
   - Formulare
   - Open Source
 repoUrl: https://github.com/Paul1404/svufo
+liveUrl: https://svufo.sv-untereuerheim.de
 status: shipped
 icon: banknote
 ---
 
-Die Kasse zu zählen und Ausgaben in einer Tabelle zu erfassen funktioniert, bis man einen sauberen, prüffähigen Nachweis braucht. Dieses Projekt ersetzt die Tabelle durch ein geführtes Formular, das ordentliche Belege erzeugt, die für die Buchhaltung bereit sind.
+Die Kasse in eine Tabelle zu zählen funktioniert, bis man einen Nachweis braucht, der einer Prüfung standhält. Dieses Projekt ersetzt die Tabelle durch ein geführtes Formular, das ordentliche Belege erzeugt, lückenlos pro Jahr nummeriert und bereit für den Steuerberater.
 
 ### Was es macht
 
-- Erfasst Kassenzählungen über alle Stückelungen und protokolliert Ausgaben mit konfigurierbaren Mehrwertsteuersätzen.
-- Nummeriert Belege automatisch pro Jahr und erzeugt PDFs mit einer SHA256-Prüfsumme.
-- Hält Korrekturen über einen Storno-Ablauf prüffähig, der den ursprünglichen Datensatz erhält, und exportiert CSV für den Steuerberater.
+- Erfasst die Zählung über alle 15 Stückelungen und protokolliert Ausgaben mit Mehrwertsteuersätzen von 0, 7 oder 19 Prozent oder einem eigenen Satz.
+- Nummeriert jeden Beleg pro Jahr und erzeugt ein PDF mit einer SHA256-Prüfsumme über die Daten.
+- Hält Korrekturen konform über einen Storno-Ablauf: Das Original bleibt unveränderlich, die Stornierung wird getrennt mit Wasserzeichen abgelegt. Exportiert CSV für den Steuerberater.
 
 ### Warum es wichtig ist
 
-Der Verein erhält Nachweise, die einer Prüfung standhalten, statt einer Tabelle, der niemand ganz vertraut. Die Ausgabe ist so gebaut, dass sie sich direkt in DATEV hochladen lässt, sodass der Buchungsschritt kurz bleibt.
+Der Verein erhält Nachweise, die den GoBD-Aufbewahrungspflichten genügen, statt einer Tabelle, der niemand ganz vertraut, und die Ausgabe lässt sich direkt in DATEV Unternehmen Online hochladen, sodass der Buchungsschritt kurz bleibt.

--- a/src/content/projects/de/svutt.md
+++ b/src/content/projects/de/svutt.md
@@ -1,11 +1,12 @@
 ---
 title: "Tischtennis-Turniere"
 publishDate: 2026-05-18 00:00:00
-description: "Eine browserbasierte Turnierverwaltung für einen Tischtennisverein. Sie übernimmt Auslosung, Gruppentabellen, K.-o.-Bäume, Zeitplan und eine Live-Ansicht für Zuschauer."
+description: "Eine browserbasierte Turnierverwaltung für einen Tischtennisverein. Sie macht aus einer Teilnehmerliste die Auslosung, Gruppentabellen, K.-o.-Bäume, einen Zeitplan über mehrere Tische und eine Live-Ansicht, die Zuschauer per QR-Code erreichen."
 stack:
   - TypeScript
   - Next.js
   - PostgreSQL
+  - Hono
 tags:
   - Verein
   - Turniere
@@ -17,14 +18,14 @@ status: shipped
 icon: trophy
 ---
 
-Ein Tischtennisturnier auf Papier zu führen bedeutet, Bäume von Hand neu zu zeichnen, Ergebnisse zwischen Blättern zu übertragen und Zuschauer um einen einzigen Ausdruck zu drängen. Dieses Projekt ersetzt das durch ein System, das der Organisator über ein Dashboard steuert.
+Ein Tischtennisturnier auf Papier zu führen bedeutet, Bäume von Hand neu zu zeichnen, Ergebnisse zwischen Blättern zu übertragen und eine Menschentraube, die auf einen einzigen Ausdruck schielt, um zu sehen, wer als Nächstes an Tisch 3 spielt. Dieses Projekt macht aus der Teilnehmerliste alles, was der Turniertag braucht, gesteuert über ein einziges Dashboard.
 
 ### Was es macht
 
-- Erzeugt die Auslosung und unterstützt mehrere Formate: Gruppen mit K.-o.-Runde, Jeder gegen Jeden, reines K.-o.-System oder Schweizer System.
-- Erfasst Ergebnisse satzweise mit Prüfung, weist Spiele den Tischen zu und erstellt den Zeitplan.
-- Gibt Zuschauern eine Live-Ansicht, die sich selbst aktualisiert und über einen QR-Code erreichbar ist.
+- Erzeugt die Auslosung und unterstützt je Konkurrenz mehrere Formate: Gruppen mit K.-o.-Runde, Jeder gegen Jeden, Jeder gegen Jeden mit Finalrunde, reines K.-o.-System oder ein Schweizer System.
+- Prüft Ergebnisse satzweise gegen die Regeln, verteilt Spiele über parallele Tische und nummeriert jedes Spiel.
+- Gibt Zuschauern eine mobile Live-Ansicht, die sich selbst aktualisiert und über Server-Sent Events sofort nachzieht, erreichbar über einen QR-Code.
 
 ### Warum es wichtig ist
 
-Der Organisator ist nicht länger der Engpass. Ergebnisse werden einmal eingetragen, und alle, Spieler wie Zuschauer, sehen denselben aktuellen Spielbaum. Jeder Verein kann das Projekt forken und sein eigenes Logo einsetzen.
+Der Organisator ist nicht länger der Engpass. Ergebnisse werden einmal eingetragen, und alle, Spieler wie Zuschauer, sehen dieselbe aktuelle Tabelle und denselben Spielbaum. Die Turnierlogik steckt in einer eigenen, abhängigkeitsfreien Engine, und jeder Verein kann das Projekt mit eigenem Namen und Logo forken.

--- a/src/content/projects/de/svutt.md
+++ b/src/content/projects/de/svutt.md
@@ -1,0 +1,30 @@
+---
+title: "Tischtennis-Turniere"
+publishDate: 2026-05-18 00:00:00
+description: "Eine browserbasierte Turnierverwaltung für einen Tischtennisverein. Sie übernimmt Auslosung, Gruppentabellen, K.-o.-Bäume, Zeitplan und eine Live-Ansicht für Zuschauer."
+stack:
+  - TypeScript
+  - Next.js
+  - PostgreSQL
+tags:
+  - Verein
+  - Turniere
+  - Open Source
+repoUrl: https://github.com/Paul1404/svutt
+liveUrl: https://svutt.sv-untereuerheim.de
+featured: true
+status: shipped
+icon: trophy
+---
+
+Ein Tischtennisturnier auf Papier zu führen bedeutet, Bäume von Hand neu zu zeichnen, Ergebnisse zwischen Blättern zu übertragen und Zuschauer um einen einzigen Ausdruck zu drängen. Dieses Projekt ersetzt das durch ein System, das der Organisator über ein Dashboard steuert.
+
+### Was es macht
+
+- Erzeugt die Auslosung und unterstützt mehrere Formate: Gruppen mit K.-o.-Runde, Jeder gegen Jeden, reines K.-o.-System oder Schweizer System.
+- Erfasst Ergebnisse satzweise mit Prüfung, weist Spiele den Tischen zu und erstellt den Zeitplan.
+- Gibt Zuschauern eine Live-Ansicht, die sich selbst aktualisiert und über einen QR-Code erreichbar ist.
+
+### Warum es wichtig ist
+
+Der Organisator ist nicht länger der Engpass. Ergebnisse werden einmal eingetragen, und alle, Spieler wie Zuschauer, sehen denselben aktuellen Spielbaum. Jeder Verein kann das Projekt forken und sein eigenes Logo einsetzen.

--- a/src/content/projects/en/astro-portfolio.md
+++ b/src/content/projects/en/astro-portfolio.md
@@ -1,0 +1,28 @@
+---
+title: "This Portfolio"
+publishDate: 2026-06-02 00:00:00
+description: "The site you are looking at. A static, bilingual portfolio built with Astro, where every project is a Markdown file in a content collection."
+stack:
+  - Astro
+  - TypeScript
+  - Tailwind CSS
+tags:
+  - Web
+  - Open Source
+repoUrl: https://github.com/Paul1404/astro-portfolio
+liveUrl: https://pd-portfolio.net
+status: shipped
+icon: globe
+---
+
+A personal site has to load fast, stay easy to update, and not turn into a maintenance project of its own. This one is a static Astro build where adding a project means writing a Markdown file, not touching components.
+
+### What it does
+
+- Renders every project from Markdown in a content collection, so new entries are one file each.
+- Serves English and German from the same source through built-in i18n routing.
+- Ships a small interactive terminal at `/terminal` and a full favicon set generated from a single SVG.
+
+### Why it matters
+
+The content and the code stay separate, so writing about a new project never means editing the site itself. It builds to plain static files and deploys to Cloudflare Pages.

--- a/src/content/projects/en/svufo.md
+++ b/src/content/projects/en/svufo.md
@@ -1,28 +1,30 @@
 ---
 title: "Cash Count Protocols"
 publishDate: 2026-05-12 00:00:00
-description: "A web app for clubs to record cash counts and expenses, then generate numbered PDF receipts that drop straight into DATEV accounting."
+description: "A web app for a club treasurer to record cash counts and expenses, then generate numbered, GoBD-compliant PDF receipts ready to upload into DATEV."
 stack:
   - TypeScript
   - Next.js
   - PostgreSQL
+  - Hono
 tags:
   - Finance
   - Forms
   - Open Source
 repoUrl: https://github.com/Paul1404/svufo
+liveUrl: https://svufo.sv-untereuerheim.de
 status: shipped
 icon: banknote
 ---
 
-Counting the till and logging expenses in a spreadsheet works until you need a clean, auditable record. This replaces the spreadsheet with a guided form that produces proper receipts ready for the accountant.
+Counting the till into a spreadsheet works until you need a record that holds up to an audit. This replaces the spreadsheet with a guided form that produces proper receipts, numbered gaplessly per year, ready for the accountant.
 
 ### What it does
 
-- Records cash counts across denominations and logs expenses with configurable VAT rates.
-- Numbers receipts automatically by year and generates PDFs with a SHA256 checksum.
-- Keeps corrections auditable through a storno workflow that preserves the original record, and exports CSV for the accountant.
+- Records the count across all 15 denominations and logs expenses with VAT rates of 0, 7, or 19 percent, or a custom rate.
+- Numbers each receipt per year and generates a PDF with a SHA256 checksum over the data.
+- Keeps corrections compliant through a storno workflow: the original stays immutable and the cancellation is filed separately with a watermark. Exports CSV for the accountant.
 
 ### Why it matters
 
-The club gets records that hold up to scrutiny instead of a spreadsheet nobody fully trusts. The output is built to upload straight into DATEV, so the bookkeeping step stays short.
+The club gets records built to satisfy GoBD retention rules instead of a spreadsheet nobody fully trusts, and the output uploads straight into DATEV Unternehmen Online, so the bookkeeping step stays short.

--- a/src/content/projects/en/svufo.md
+++ b/src/content/projects/en/svufo.md
@@ -1,0 +1,28 @@
+---
+title: "Cash Count Protocols"
+publishDate: 2026-05-12 00:00:00
+description: "A web app for clubs to record cash counts and expenses, then generate numbered PDF receipts that drop straight into DATEV accounting."
+stack:
+  - TypeScript
+  - Next.js
+  - PostgreSQL
+tags:
+  - Finance
+  - Forms
+  - Open Source
+repoUrl: https://github.com/Paul1404/svufo
+status: shipped
+icon: banknote
+---
+
+Counting the till and logging expenses in a spreadsheet works until you need a clean, auditable record. This replaces the spreadsheet with a guided form that produces proper receipts ready for the accountant.
+
+### What it does
+
+- Records cash counts across denominations and logs expenses with configurable VAT rates.
+- Numbers receipts automatically by year and generates PDFs with a SHA256 checksum.
+- Keeps corrections auditable through a storno workflow that preserves the original record, and exports CSV for the accountant.
+
+### Why it matters
+
+The club gets records that hold up to scrutiny instead of a spreadsheet nobody fully trusts. The output is built to upload straight into DATEV, so the bookkeeping step stays short.

--- a/src/content/projects/en/svutt.md
+++ b/src/content/projects/en/svutt.md
@@ -1,0 +1,30 @@
+---
+title: "Table Tennis Tournaments"
+publishDate: 2026-05-18 00:00:00
+description: "A browser-based tournament manager for a table tennis club. Handles draws, group tables, knockout brackets, scheduling, and a live public view for spectators."
+stack:
+  - TypeScript
+  - Next.js
+  - PostgreSQL
+tags:
+  - Sports Club
+  - Tournaments
+  - Open Source
+repoUrl: https://github.com/Paul1404/svutt
+liveUrl: https://svutt.sv-untereuerheim.de
+featured: true
+status: shipped
+icon: trophy
+---
+
+Running a table tennis tournament on paper means redrawing brackets by hand, copying results between sheets, and crowding spectators around a single printout. This replaces all of that with one system the organizer drives from a dashboard.
+
+### What it does
+
+- Generates draws and supports several formats: groups with knockout, round robin, pure knockout, or Swiss system.
+- Tracks per-set results with validation, assigns matches to tables, and builds the schedule.
+- Gives spectators a live public view that refreshes on its own, reachable by scanning a QR code.
+
+### Why it matters
+
+The organizer stops being a bottleneck. Results go in once and everyone, players and spectators alike, sees the same up-to-date bracket. Any club can fork it and drop in their own logo.

--- a/src/content/projects/en/svutt.md
+++ b/src/content/projects/en/svutt.md
@@ -1,11 +1,12 @@
 ---
 title: "Table Tennis Tournaments"
 publishDate: 2026-05-18 00:00:00
-description: "A browser-based tournament manager for a table tennis club. Handles draws, group tables, knockout brackets, scheduling, and a live public view for spectators."
+description: "A browser-based tournament manager built for a table tennis club. Turns a participant list into draws, group tables, knockout brackets, a schedule across tables, and a live public view spectators reach by QR code."
 stack:
   - TypeScript
   - Next.js
   - PostgreSQL
+  - Hono
 tags:
   - Sports Club
   - Tournaments
@@ -17,14 +18,14 @@ status: shipped
 icon: trophy
 ---
 
-Running a table tennis tournament on paper means redrawing brackets by hand, copying results between sheets, and crowding spectators around a single printout. This replaces all of that with one system the organizer drives from a dashboard.
+Running a table tennis tournament on paper means redrawing brackets by hand, copying results between sheets, and a crowd squinting at one printout to find out who plays at table 3 next. This turns the participant list into everything the day needs, driven from a single admin dashboard.
 
 ### What it does
 
-- Generates draws and supports several formats: groups with knockout, round robin, pure knockout, or Swiss system.
-- Tracks per-set results with validation, assigns matches to tables, and builds the schedule.
-- Gives spectators a live public view that refreshes on its own, reachable by scanning a QR code.
+- Generates the draw and supports several formats per division: groups with knockout, round robin, round robin with finals, pure knockout, or a Swiss system.
+- Validates results set by set against the rules, distributes matches across parallel tables, and numbers every game.
+- Gives spectators a mobile public view that refreshes on its own and updates live over server-sent events, reachable by scanning a QR code.
 
 ### Why it matters
 
-The organizer stops being a bottleneck. Results go in once and everyone, players and spectators alike, sees the same up-to-date bracket. Any club can fork it and drop in their own logo.
+The organizer stops being the bottleneck. Results are entered once and everyone, players and spectators alike, sees the same up-to-date standings and bracket. The tournament logic sits in a separate, dependency-free engine, and any club can fork it with their own name and logo.


### PR DESCRIPTION
Adds three more public projects to the portfolio, each in English and German.

## New projects

- **This Portfolio** (`astro-portfolio`) - the site itself. Static, bilingual Astro build, repo + live link. Icon: `globe`.
- **Table Tennis Tournaments** (`svutt`) - browser-based tournament manager with draws, brackets, scheduling and a live public view. Repo + live demo at svutt.sv-untereuerheim.de. Marked featured. Icon: `trophy`.
- **Cash Count Protocols** (`svufo`) - web app for clubs to record cash counts and expenses and generate numbered PDF receipts for DATEV. Repo only, no live URL. Icon: `banknote`.

Descriptions were drawn from each repo's README rather than guessed. `svums` and `dmo` already existed and were left unchanged.

## Notes

- Each project is two Markdown files under `src/content/projects/{en,de}/`, matching the existing content-collection format.
- Copy follows the project rules: no dashes used as pauses, no marketing language.
- `npm run build` passes; all six entries generate pages in both locales.

https://claude.ai/code/session_0111wVcq88qtCzDpFErjoxwv

---
_Generated by [Claude Code](https://claude.ai/code/session_0111wVcq88qtCzDpFErjoxwv)_