### PR TITLE
feat(projects): order featured projects first on listings

### DIFF
--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -13,10 +13,20 @@ export function langOf(entry: Project): string {
 	return entry.id.split('/')[0];
 }
 
-/** All projects for a locale, newest first. */
+/**
+ * All projects for a locale, most mature and impressive first.
+ *
+ * Featured projects lead the list, then everything else. Within each tier the
+ * newest projects come first, so the ordering still reflects recency.
+ */
 export async function getProjects(lang: Lang): Promise<Project[]> {
 	const all = await getCollection('projects');
 	return all
 		.filter((entry) => langOf(entry) === lang)
-		.sort((a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf());
+		.sort((a, b) => {
+			if (a.data.featured !== b.data.featured) {
+				return a.data.featured ? -1 : 1;
+			}
+			return b.data.publishDate.valueOf() - a.data.publishDate.valueOf();
+		});
 }


### PR DESCRIPTION
## What

Projects now lead with the mature, impressive work instead of sorting purely by date.

`getProjects` was sorting every project newest-first. It now sorts featured projects (`featured: true`) to the front, then everything else, keeping newest-first as the tiebreaker within each tier.

The featured set is already curated in the content frontmatter and is consistent across both locales: BFV Match Exporter, Diatrack, Dependabot Mass Orchestration, Email Signature Builder, Sigil, and Table Tennis Tournaments.

## Why

The projects page showed a flat reverse-chronological list, so a small CLI helper could outrank a full shipped app just by having a newer publish date. Leading with featured work puts the strongest projects in front of visitors first.

## Effect

- `/projects` and `/de/projects`: featured projects appear first, then the rest by date.
- Home page: the featured grid is now ordered by date within the featured tier (previously arbitrary collection order).

Change is centralized in `src/lib/projects.ts`. `astro build` passes.

https://claude.ai/code/session_01UhaqyAerV2ojDMaecbUZg2

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhaqyAerV2ojDMaecbUZg2)_