### PR TITLE
feat(analytics): add umami tracking and session replay

### DIFF
--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -75,6 +75,31 @@ const ogLocaleAlt = lang === 'de' ? 'en_US' : 'de_DE';
 <meta name="twitter:image" content={ogImage} />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+
+{
+	/* Umami analytics. Only loaded in production builds so local dev and
+	   previews don't pollute the stats. The recorder enables privacy-masked
+	   session replay (15% sample, moderate masking, 5 min max). */
+	import.meta.env.PROD && (
+		<>
+			<script
+				is:inline
+				defer
+				src="https://umami.pdcd.net/script.js"
+				data-website-id="26620834-5f2e-4d5f-a4c1-3ad51d7a0f2a"
+			/>
+			<script
+				is:inline
+				defer
+				src="https://umami.pdcd.net/recorder.js"
+				data-website-id="26620834-5f2e-4d5f-a4c1-3ad51d7a0f2a"
+				data-sample-rate="0.15"
+				data-mask-level="moderate"
+				data-max-duration="300000"
+			/>
+		</>
+	)
+}
 <link
 	href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Space+Grotesk:wght@500;600;700&display=swap"
 	rel="stylesheet"

--- a/src/components/pages/PrivacyPage.astro
+++ b/src/components/pages/PrivacyPage.astro
@@ -115,7 +115,28 @@ const t = useTranslations(lang);
 							</a>
 						</p>
 
-						<h2 id="impressum">Impressum</h2>
+						<h2>Webanalyse mit Umami</h2>
+							<p>
+								Wir nutzen Umami, eine selbst gehostete Analyse-Software, um die Nutzung unserer
+								Website auszuwerten. Umami arbeitet cookielos und setzt keine geräteübergreifenden
+								Kennungen ein. IP-Adressen werden nicht gespeichert. Erhoben werden anonyme
+								Nutzungsdaten wie aufgerufene Seiten, ungefährer Standort auf Länderebene, Browser
+								und Betriebssystem. Die Daten werden auf unseren eigenen Servern verarbeitet und
+								nicht an Dritte weitergegeben. Rechtsgrundlage ist unser berechtigtes Interesse an
+								einer datensparsamen Reichweitenmessung (Art. 6 Abs. 1 lit. f DSGVO).
+							</p>
+							<h3>Session-Aufzeichnung (Session Replay)</h3>
+							<p>
+								Zusätzlich zeichnet Umami einen Teil der Sitzungen anonymisiert auf, um die
+								Bedienbarkeit der Website zu verbessern. Aufgezeichnet werden nur etwa 15 Prozent der
+								Sitzungen, und Eingaben sowie Texte werden vor der Speicherung maskiert. Es werden
+								keine Tastatureingaben im Klartext und keine sensiblen Inhalte erfasst. Auch diese
+								Verarbeitung erfolgt auf Grundlage unseres berechtigten Interesses (Art. 6 Abs. 1
+								lit. f DSGVO). Sie können der Aufzeichnung jederzeit widersprechen, indem Sie uns über
+								die im Impressum genannten Kontaktdaten kontaktieren.
+							</p>
+
+							<h2 id="impressum">Impressum</h2>
 						<h4>Angaben gemäß § 5 TMG</h4>
 						<p>
 							Paul Dresch<br />
@@ -226,7 +247,26 @@ const t = useTranslations(lang);
 							</a>
 						</p>
 
-						<h2 id="impressum">Legal Notice (Impressum)</h2>
+						<h2>Web analytics with Umami</h2>
+							<p>
+								We use Umami, a self-hosted analytics tool, to understand how our website is used.
+								Umami works without cookies and does not use cross-device identifiers. IP addresses
+								are not stored. We collect anonymous usage data such as the pages visited, an
+								approximate location at country level, browser, and operating system. The data is
+								processed on our own servers and is not shared with third parties. The legal basis is
+								our legitimate interest in privacy-friendly audience measurement (Art. 6(1)(f) GDPR).
+							</p>
+							<h3>Session replay</h3>
+							<p>
+								In addition, Umami records a portion of sessions in anonymized form to help us
+								improve the usability of the website. Only about 15 percent of sessions are recorded,
+								and form inputs and text are masked before they are stored. No keystrokes in plain
+								text and no sensitive content are captured. This processing is also based on our
+								legitimate interest (Art. 6(1)(f) GDPR). You can object to the recording at any time
+								by contacting us using the details in the Legal Notice.
+							</p>
+
+							<h2 id="impressum">Legal Notice (Impressum)</h2>
 						<h4>Information according to § 5 TMG</h4>
 						<p>
 							Paul Dresch<br />


### PR DESCRIPTION
## What

Adds self-hosted Umami analytics to the site.

- Loads `https://umami.pdcd.net/script.js` (cookieless analytics) on every page via `MainHead.astro`.
- Loads `https://umami.pdcd.net/recorder.js` for session replay (15% sample, moderate masking, 5 min max duration).
- Both scripts use `is:inline` (so Astro leaves them untouched) and `defer`.
- Both are gated behind `import.meta.env.PROD`, so local dev and previews do not pollute the stats.

## Privacy

The site is GDPR-conscious (privacy policy, Impressum, cookie consent) and the recorder records user sessions. The privacy policy previously only documented Cloudflare, so this PR adds an Umami section in both German and English covering the cookieless analytics and the masked session replay, with the legal basis (Art. 6(1)(f) GDPR) and an opt-out note.

> Note: the disclosure text is a factual draft describing what is deployed. Have it reviewed before relying on it legally, and confirm whether session replay should require explicit consent in your setup rather than legitimate interest.

## Verification

- `npm run build` passes (56 pages).
- Confirmed both scripts render into the built HTML on all 56 pages.

https://claude.ai/code/session_01NgP9DN2jdUXt44mSd66NFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgP9DN2jdUXt44mSd66NFm)_